### PR TITLE
Fix `list` command

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,7 @@
-on: ["push", "pull_request"]
+on:
+  pull_request:
+  push:
+    branches: ["master"]
 name: Check & Build on PRs and push
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Lint
       run: $GITHUB_WORKSPACE/golangci-lint run ./...
 
-    - name: Submit coverage:
+    - name: Submit coverage
       run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverprofile.out
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,32 @@
+on: ["push", "pull_request"]
+name: Check & Build on PRs and push
+
+jobs:
+  name: Check & Build
+  runs-on: ubuntu-latest
+  steps:
+    - name: Setup Go 1.16
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+      id: go
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: |
+        go test -v -timeout=5m -covermode=count -coverprofile=$GITHUB_WORKSPACE/coverprofile.out ./...
+
+    - name: Install golangci-lint and goveralls
+      run: |
+         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.43.0
+         GO111MODULE=off go get -u github.com/mattn/goveralls
+
+    - name: Lint
+      run: $GITHUB_WORKSPACE/golangci-lint run ./...
+
+    - name: Submit coverage:
+      run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverprofile.out
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,31 +2,31 @@ on: ["push", "pull_request"]
 name: Check & Build on PRs and push
 
 jobs:
-  name: Check & Build
-  runs-on: ubuntu-latest
-  steps:
-    - name: Setup Go 1.16
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
-      id: go
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+        id: go
 
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Test
-      run: |
-        go test -v -timeout=5m -covermode=count -coverprofile=$GITHUB_WORKSPACE/coverprofile.out ./...
+      - name: Test
+        run: |
+          go test -v -timeout=5m -covermode=count -coverprofile=$GITHUB_WORKSPACE/coverprofile.out ./...
 
-    - name: Install golangci-lint and goveralls
-      run: |
-         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.43.0
-         GO111MODULE=off go get -u github.com/mattn/goveralls
+      - name: Install golangci-lint and goveralls
+        run: |
+           curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.43.0
+           GO111MODULE=off go get -u github.com/mattn/goveralls
 
-    - name: Lint
-      run: $GITHUB_WORKSPACE/golangci-lint run ./...
+      - name: Lint
+        run: $GITHUB_WORKSPACE/golangci-lint run ./...
 
-    - name: Submit coverage
-      run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverprofile.out
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Submit coverage
+        run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverprofile.out
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -43,9 +43,10 @@ func collectManifests(root string) ([]string, error) {
 	for _, entry := range dirs {
 		if !entry.IsDir() {
 			if entry.Name() == "projector.toml" {
-				manifests = append(manifests, strings.TrimLeft(root, embedRoot)) //nolint:staticcheck
+				manifestName := strings.TrimPrefix(root, embedRoot)
+				manifests = append(manifests, manifestName) //nolint:staticcheck
 
-				verbose.Printf("projector.toml detected, so registered %q as manifest", root)
+				verbose.Printf("projector.toml detected, so registered %q as manifest", manifestName)
 			}
 
 			continue

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -150,7 +150,6 @@ func (g *Generator) RenderOutputPath(f manifest.File) (string, error) {
 		return "", fmt.Errorf("render output path template %q: %w", f.Output, err)
 	}
 
-	// return filepath.Join(g.config.WorkingDirectory, outputPath.String()), nil
 	return outputPath.String(), nil
 }
 

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -311,7 +311,7 @@ func TestGenerator_Generate(t *testing.T) {
 	// obtain go version without patch and "go" prefix, e.g. "1.16"
 	var (
 		goVersionWithPatch = strings.TrimLeft(runtime.Version(), "go")
-		goVersion          = goVersionWithPatch[:len(goVersionWithPatch)-2]
+		goVersion          = strings.Split(goVersionWithPatch, ".")[1]
 	)
 
 	testCases := []testCase{
@@ -335,7 +335,7 @@ func TestGenerator_Generate(t *testing.T) {
 				},
 				{
 					path:    "testdata/output/projector-test/go.mod",
-					content: fmt.Sprintf("module projector-test\n\ngo %s\n", goVersion),
+					content: fmt.Sprintf("module projector-test\n\ngo 1.%s\n", goVersion),
 				},
 			},
 		},


### PR DESCRIPTION
Command `list` was using `strings.TrimLeft` to trim `resources/templates/` prefix to print clear template names, but it works incorrectly in some cases. Replaced with `strings.TrimPrefix`.